### PR TITLE
Suggest clang-format style to ease contributions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+---
+Language:      Cpp
+BasedOnStyle:  Google
+
+AccessModifierOffset: 0
+IndentAccessModifiers: true
+
+AlignAfterOpenBracket: BlockIndent
+AlignEscapedNewlines: Left
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: false
+#     
+BreakBeforeBraces: Custom
+AllowShortLambdasOnASingleLine: Empty
+BraceWrapping:   
+  AfterClass:            false
+  AfterControlStatement: false
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterStruct:           false
+  AfterUnion:            true
+  AfterExternBlock:      true
+  BeforeCatch:           true
+  BeforeElse:            false
+  SplitEmptyFunction:    true
+  SplitEmptyRecord:      true
+  SplitEmptyNamespace:   true
+  BeforeLambdaBody:      false
+BreakInheritanceList: AfterComma
+# BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+PackConstructorInitializers: CurrentLine
+# BreakConstructorInitializers: BeforeColon
+# BreakStringLiterals: true
+ColumnLimit:     127
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false
+# ConstructorInitializerIndentWidth: 2
+IndentCaseLabels: true
+ContinuationIndentWidth: 2
+FixNamespaceComments: false
+IncludeBlocks:   Preserve
+IndentWidth:     2
+NamespaceIndentation: Inner
+SpaceAfterTemplateKeyword: false
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterOverloadedOperator: false
+TabWidth:        2
+UseTab:          Never
+
+
+## The following we more inconsisten than other features, these are my
+#  suggestions that seemed to match the majority of the codebase best
+#DerivePointerAlignment: true
+PointerAlignment: Right
+#SpaceAroundPointerQualifiers: Default
+ReferenceAlignment: Left

--- a/src/error_handler/ErrorHandler.hpp
+++ b/src/error_handler/ErrorHandler.hpp
@@ -8,20 +8,20 @@
     without restriction, including without l> imitation the rights to use, copy, modify, merge,
     publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
     to whom the Software is furnished to do so, subject to the following conditions:
-    The above copyright notice and this permission notice shall be included in all copies or 
+    The above copyright notice and this permission notice shall be included in all copies or
     substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
     OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 // Include declarations
-#include <string>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 /* CODE START */
 
@@ -33,16 +33,15 @@ namespace error_handler {
         NIL,
         ERROR,
         WARNING,
-        INFO
+        INFO,
       };
 
       // Fix constructor initialization list
-      ErrorHandler(error_type type) : error_type_(type) {
-      }
+      ErrorHandler(error_type type) : error_type_(type) {}
 
       ~ErrorHandler() = default;
 
-      void HandleError(const std::string &error_message) {
+      void HandleError(const std::string& error_message) {
         std::stringstream formatted_message;
         // Prefix message based on error type
         switch (error_type_) {
@@ -75,4 +74,4 @@ namespace error_handler {
 }
 }
 
-#endif // PARASYTE_ERROR_HANDLER_ERRORHANDLER_HPP_
+#endif  // PARASYTE_ERROR_HANDLER_ERRORHANDLER_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,28 +1,31 @@
+#include <iostream>
 #include "network/NetScanner.hpp"
 #include "network/NetUtils.hpp"
-#include <iostream>
 
 int main() {
-    try {
-        boost::asio::io_context io_context;
-        std::string host = "192.168.88.88";
-        parasyte::network::utils::RawProtocol protocol = parasyte::network::utils::RawProtocol::v4();
-        int timeout = 10000;
-        parasyte::network::NetScanner scanner(io_context, host, protocol, timeout);
-        uint16_t port_to_scan = 22;
-        scanner.StartScan(port_to_scan);
-        io_context.run();
-        std::cout << "PORT\tSTATUS" << "\n";
-        for (auto pair : scanner.port_info()) {
-            using pstate = parasyte::network::NetScanner::port_status;
-            static std::map<pstate, std::string> const pstr = {
-                {pstate::OPEN, "open"}, {pstate::CLOSED, "closed"},
-                {pstate::FILTERED, "filtered"}, {pstate::ABORTED, "aborted"}
-            };
-            std::cout << pair.first << '\t' << pstr.at(pair.second) << "\n";
-        }
-    } catch (const std::exception &e) {
-        std::cerr << "Exception: " << e.what() << "\n"; 
+  try {
+    boost::asio::io_context io_context;
+    std::string host = "192.168.88.88";
+    parasyte::network::utils::RawProtocol protocol = parasyte::network::utils::RawProtocol::v4();
+    int timeout = 10000;
+    parasyte::network::NetScanner scanner(io_context, host, protocol, timeout);
+    uint16_t port_to_scan = 22;
+    scanner.StartScan(port_to_scan);
+    io_context.run();
+    std::cout << "PORT\tSTATUS\n";
+    for (auto pair : scanner.port_info()) {
+      using pstate = parasyte::network::NetScanner::port_status;
+      static std::map<pstate, std::string> const pstr = {
+        {pstate::OPEN, "open"},
+        {pstate::CLOSED, "closed"},
+        {pstate::FILTERED, "filtered"},
+        {pstate::ABORTED, "aborted"},
+      };
+      std::cout << pair.first << '\t' << pstr.at(pair.second) << "\n";
     }
-    return 0;
+  }
+  catch (const std::exception& e) {
+    std::cerr << "Exception: " << e.what() << "\n";
+  }
+  return 0;
 }

--- a/src/network/NetScanner.hpp
+++ b/src/network/NetScanner.hpp
@@ -8,57 +8,57 @@
     without restriction, including without l> imitation the rights to use, copy, modify, merge,
     publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
     to whom the Software is furnished to do so, subject to the following conditions:
-    The above copyright notice and this permission notice shall be included in all copies or 
+    The above copyright notice and this permission notice shall be included in all copies or
     substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
     OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 // Include declarations
+#include <netinet/in.h>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <set>
 #include <string>
 #include <tuple>
-#include <map>
-#include <set>
-#include <chrono>
-#include <memory>
-#include <netinet/in.h>
 
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/basic_waitable_timer.hpp>
-#include <boost/asio/streambuf.hpp>
 #include <boost/asio/basic_raw_socket.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/streambuf.hpp>
 
-#include "NetUtils.hpp"
 #include "../error_handler/ErrorHandler.hpp"
+#include "NetUtils.hpp"
 
 /* CODE START */
 
 namespace parasyte {
 namespace network {
   class NetScanner {
-    using error_code = boost::system::error_code;
-    using stream_buffer = boost::asio::streambuf;
-    using basic_timer = boost::asio::basic_waitable_timer<std::chrono::steady_clock>;
-    using shared_timer = std::shared_ptr<basic_timer>;
-    using shared_buffer = std::shared_ptr<stream_buffer>;
+      using error_code = boost::system::error_code;
+      using stream_buffer = boost::asio::streambuf;
+      using basic_timer = boost::asio::basic_waitable_timer<std::chrono::steady_clock>;
+      using shared_timer = std::shared_ptr<basic_timer>;
+      using shared_buffer = std::shared_ptr<stream_buffer>;
 
-    struct ScanInfo {
-      uint16_t port;
-      std::chrono::steady_clock::time_point send_time;
-      uint16_t sequence_number = 0;
-      uint16_t own_port = 0;
-    };
+      struct ScanInfo {
+          uint16_t port;
+          std::chrono::steady_clock::time_point send_time;
+          uint16_t sequence_number = 0;
+          uint16_t own_port = 0;
+      };
 
     public:
       enum port_status {
         OPEN,
         CLOSED,
         FILTERED,
-        ABORTED
+        ABORTED,
       };
 
       enum {
@@ -66,11 +66,16 @@ namespace network {
         buffer_size = 2048,
       };
 
-      NetScanner(boost::asio::io_context &io_context, const std::string &host, parasyte::network::utils::RawProtocol::basic_raw_socket::protocol_type protocol, int miliseconds);
+      NetScanner(
+        boost::asio::io_context& io_context,
+        const std::string& host,
+        parasyte::network::utils::RawProtocol::basic_raw_socket::protocol_type protocol,
+        int miliseconds
+      );
       ~NetScanner();
 
       void StartScan(uint16_t port_number);
-      std::map<int, port_status> const &port_info() const;
+      std::map<int, port_status> const& port_info() const;
 
     private:
       void StartTimer(int milliseconds, ScanInfo scan_info, shared_timer timer);
@@ -79,25 +84,23 @@ namespace network {
       void HandleReceive(error_code error, std::size_t len, ScanInfo scan_info, shared_buffer buffer, shared_timer timer);
       void Timeout(error_code error, ScanInfo scan_info, shared_timer timer);
       using SrcSeq = std::tuple<uint16_t, uint32_t>;
-      SrcSeq MakeSegment(stream_buffer &buffer, uint16_t port);
-      SrcSeq MakeIPv4Segment(stream_buffer &buffer, uint16_t port);
-      SrcSeq MakeIPv6Segment(stream_buffer &buffer, uint16_t port);
+      SrcSeq MakeSegment(stream_buffer& buffer, uint16_t port);
+      SrcSeq MakeIPv4Segment(stream_buffer& buffer, uint16_t port);
+      SrcSeq MakeIPv6Segment(stream_buffer& buffer, uint16_t port);
       void PopulatePortInfo(int port, port_status status);
 
       int timeout_miliseconds_;
       std::set<uint16_t> timeout_port_;
-      boost::asio::io_context &io_context_;
+      boost::asio::io_context& io_context_;
       parasyte::network::utils::RawProtocol::basic_raw_socket socket_;
       parasyte::network::utils::RawProtocol::basic_raw_socket::protocol_type protocol_;
       parasyte::network::utils::RawProtocol::endpoint destination_;
       std::map<int, port_status> port_info_;
       parasyte::network::utils::RouteTableIPv4 route_table_ipv4_;
-      parasyte::network::utils::RouteTableIPv6 route_table_ipv6_; 
+      parasyte::network::utils::RouteTableIPv6 route_table_ipv6_;
       parasyte::error_handler::ErrorHandler error_handler_;
-
-  };  
+  };
 }
 }
 
-
-#endif // PARASYTE_NETWORK_NETSCANNER_HPP_
+#endif  // PARASYTE_NETWORK_NETSCANNER_HPP_

--- a/src/network/NetUtils.cpp
+++ b/src/network/NetUtils.cpp
@@ -5,51 +5,51 @@
     without restriction, including without l> imitation the rights to use, copy, modify, merge,
     publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
     to whom the Software is furnished to do so, subject to the following conditions:
-    The above copyright notice and this permission notice shall be included in all copies or 
+    The above copyright notice and this permission notice shall be included in all copies or
     substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
     OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 // Include declarations
 
 #include "NetUtils.hpp"
+#include <arpa/inet.h>
 #include <iostream>
-#include <arpa/inet.h> 
 
 /* CODE START */
 
 /**
  * Calculates the checksum of a buffer.
- * 
+ *
  * @param buffer The buffer containing the data to calculate the checksum for.
  * @param buffer_size The size of the buffer in bytes.
  * @return The calculated checksum value.
  */
-uint16_t parasyte::network::utils::Checksum(std::uint16_t *buffer, size_t buffer_size) {
-  unsigned long sum = 0; // Initialize the sum variable to 0
-  while (buffer_size > 1) { // Iterate through the buffer in 16-bit chunks
-    sum += *buffer++; // Add the value at the current buffer location to the sum
-    buffer_size -= 2; // Decrease the buffer size by 2 bytes
+uint16_t parasyte::network::utils::Checksum(std::uint16_t* buffer, size_t buffer_size) {
+  unsigned long sum = 0;     // Initialize the sum variable to 0
+  while (buffer_size > 1) {  // Iterate through the buffer in 16-bit chunks
+    sum += *buffer++;        // Add the value at the current buffer location to the sum
+    buffer_size -= 2;        // Decrease the buffer size by 2 bytes
   }
-  
-  if (buffer_size == 1) sum += *(unsigned char *)buffer; // If there is an odd byte remaining, add it to the sum
-  sum = (sum & 0xFFFF) + (sum >> 16); // Add the carry bits to the sum
-  sum = (sum & 0xFFFF) + (sum >> 16); // Add any remaining carry bits
-  return static_cast<uint16_t>(~sum); // Return the one's complement of the sum as the checksum value
+
+  if (buffer_size == 1) sum += *(unsigned char*)buffer;  // If there is an odd byte remaining, add it to the sum
+  sum = (sum & 0xFFFF) + (sum >> 16);                    // Add the carry bits to the sum
+  sum = (sum & 0xFFFF) + (sum >> 16);                    // Add any remaining carry bits
+  return static_cast<uint16_t>(~sum);                    // Return the one's complement of the sum as the checksum value
 }
 
 /**
  * Converts an IPv6 address to a string representation.
- * 
+ *
  * @param addr The IPv6 address to convert.
  * @return The string representation of the IPv6 address.
  */
-std::string parasyte::network::utils::Inet6AddressToString(const struct in6_addr *addr) {
+std::string parasyte::network::utils::Inet6AddressToString(const struct in6_addr* addr) {
   char str[INET6_ADDRSTRLEN];
   inet_ntop(AF_INET6, addr, str, INET6_ADDRSTRLEN);
   return std::string(str);
@@ -57,11 +57,11 @@ std::string parasyte::network::utils::Inet6AddressToString(const struct in6_addr
 
 /**
  * Converts an IPv4 address to a string representation.
- * 
+ *
  * @param addr The IPv4 address to convert.
  * @return The string representation of the IPv4 address.
  */
-std::string parasyte::network::utils::Inet4AddressToString(const struct in_addr *addr) {
+std::string parasyte::network::utils::Inet4AddressToString(const struct in_addr* addr) {
   char str[INET_ADDRSTRLEN];
   inet_ntop(AF_INET, addr, str, INET_ADDRSTRLEN);
   return std::string(str);
@@ -69,44 +69,46 @@ std::string parasyte::network::utils::Inet4AddressToString(const struct in_addr 
 
 /**
  * Retrieves the IPv4 address associated with a given network interface.
- * 
+ *
  * @param if_name The name of the network interface.
  * @return The IPv4 address associated with the network interface.
  */
-boost::asio::ip::address_v4 parasyte::network::utils::GetIPv4Address(const std::string &if_name) {
-  int socket_fd = socket(AF_INET, SOCK_DGRAM, 0); // Create a socket for communication
-  struct ifreq ifr; // Create a structure to hold the network interface information
-  ifr.ifr_addr.sa_family = AF_INET; // Set the address family to IPv4
-  strncpy(ifr.ifr_name, if_name.c_str(), IFNAMSIZ-1); // Copy the network interface name to the structure
-  ioctl(socket_fd, SIOCGIFADDR, &ifr); // Retrieve the network interface address using the ioctl system call
-  close(socket_fd); // Close the socket
-  return boost::asio::ip::address_v4(ntohl(((struct sockaddr_in *) &ifr.ifr_addr) -> sin_addr.s_addr)); // Convert the retrieved address to boost::asio::ip::address_v4 format and return it
+boost::asio::ip::address_v4 parasyte::network::utils::GetIPv4Address(const std::string& if_name) {
+  int socket_fd = socket(AF_INET, SOCK_DGRAM, 0);        // Create a socket for communication
+  struct ifreq ifr;                                      // Create a structure to hold the network interface information
+  ifr.ifr_addr.sa_family = AF_INET;                      // Set the address family to IPv4
+  strncpy(ifr.ifr_name, if_name.c_str(), IFNAMSIZ - 1);  // Copy the network interface name to the structure
+  ioctl(socket_fd, SIOCGIFADDR, &ifr);                   // Retrieve the network interface address using the ioctl system call
+  close(socket_fd);                                      // Close the socket
+  // Convert the retrieved address to boost::asio::ip::address_v4 format and return it
+  return boost::asio::ip::address_v4(ntohl(((struct sockaddr_in*)&ifr.ifr_addr)->sin_addr.s_addr));
 }
 
 /**
  * Retrieves the IPv6 address associated with a given network interface.
- * 
+ *
  * @param if_name The name of the network interface.
  * @return The IPv6 address associated with the network interface.
  */
-boost::asio::ip::address_v6 parasyte::network::utils::GetIPv6Address(const std::string &if_name) {
-  int socket_fd = socket(AF_INET6, SOCK_DGRAM, 0); // Create a socket for communication
-  struct ifreq ifr; // Create a structure to hold the network interface information
-  ifr.ifr_addr.sa_family = AF_INET6; // Set the address family to IPv6
-  strncpy(ifr.ifr_name, if_name.c_str(), IFNAMSIZ-1); // Copy the network interface name to the structure
-  ioctl(socket_fd, SIOCGIFADDR, &ifr); // Retrieve the network interface address using the ioctl system call
-  close(socket_fd); // Close the socket
-  std::string address_string = Inet6AddressToString(&((struct sockaddr_in6 *)&ifr.ifr_addr)->sin6_addr);
-  return boost::asio::ip::make_address_v6(address_string); // Convert the retrieved address to boost::asio::ip::address_v6 format and return it
+boost::asio::ip::address_v6 parasyte::network::utils::GetIPv6Address(const std::string& if_name) {
+  int socket_fd = socket(AF_INET6, SOCK_DGRAM, 0);       // Create a socket for communication
+  struct ifreq ifr;                                      // Create a structure to hold the network interface information
+  ifr.ifr_addr.sa_family = AF_INET6;                     // Set the address family to IPv6
+  strncpy(ifr.ifr_name, if_name.c_str(), IFNAMSIZ - 1);  // Copy the network interface name to the structure
+  ioctl(socket_fd, SIOCGIFADDR, &ifr);                   // Retrieve the network interface address using the ioctl system call
+  close(socket_fd);                                      // Close the socket
+  std::string address_string = Inet6AddressToString(&((struct sockaddr_in6*)&ifr.ifr_addr)->sin6_addr);
+  // Convert the retrieved address to boost::asio::ip::address_v6 format and return it
+  return boost::asio::ip::make_address_v6(address_string);
 }
 
 /**
  * Inserts colons into an IPv6 address string to format it properly.
- * 
+ *
  * @param str The IPv6 address string to format.
  * @return The formatted IPv6 address string.
  */
-std::string parasyte::network::utils::ReadIPv6Address(std::string &str) {
+std::string parasyte::network::utils::ReadIPv6Address(std::string& str) {
   for (unsigned i = 4; i != str.size(); i += 5) {
     str.insert(i, ":");
   }
@@ -114,12 +116,12 @@ std::string parasyte::network::utils::ReadIPv6Address(std::string &str) {
 }
 
 /** Converts a string representation of an IPv6 address to a struct in6_addr.
-* 
-* @param address The string representation of the IPv6 address.
-* @return The struct in6_addr representing the IPv6 address.
-*/
+ *
+ * @param address The string representation of the IPv6 address.
+ * @return The struct in6_addr representing the IPv6 address.
+ */
 
-#include <netinet/in.h> // Include the header file that defines the in6_addr structure
+#include <netinet/in.h>  // Include the header file that defines the in6_addr structure
 
 struct in6_addr parasyte::network::utils::StringToAddress(std::string address) {
   struct in6_addr addr;
@@ -143,64 +145,74 @@ parasyte::network::utils::RouteTableIPv4::RouteTableIPv4() {
 
 /**
  * Finds the default IPv4 route in the route table.
- * 
+ *
  * @return An iterator pointing to the default IPv4 route, or `route_info_list_.end()` if not found.
  */
-std::vector<parasyte::network::utils::RouteInfoIPv4>::const_iterator parasyte::network::utils::RouteTableIPv4::DefaultIPv4Route() const {
+std::vector<parasyte::network::utils::RouteInfoIPv4>::const_iterator
+parasyte::network::utils::RouteTableIPv4::DefaultIPv4Route() const {
   // Use std::find_if algorithm to search for the default IPv4 route in the route_info_list_
-  return std::find_if(route_info_list_.begin(), route_info_list_.end(), [](RouteInfoIPv4 const& route_info){
+  return std::find_if(route_info_list_.begin(), route_info_list_.end(), [](RouteInfoIPv4 const& route_info) {
     // The lambda function is the callback that is passed to std::find_if
     // It takes a RouteInfoIPv4 object as input and returns a boolean value
     // The lambda function checks if the destination address of the route_info object is equal to boost::asio::ip::address_v4()
-    // If it is, it returns true and std::find_if stops the search and returns the iterator pointing to the current route_info object
-    // If it is not, it returns false and std::find_if continues the search
+    // If it is, it returns true and std::find_if stops the search and returns the iterator pointing to the current route_info
+    // object If it is not, it returns false and std::find_if continues the search
     return route_info.dest == boost::asio::ip::address_v4();
   });
 }
 
 /**
  * Finds the route in the route table that matches the given target IPv4 address.
- * 
+ *
  * @param target The target IPv4 address to find in the route table.
  * @return An iterator pointing to the matching route, or `route_info_list_.end()` if not found.
  */
-std::vector<parasyte::network::utils::RouteInfoIPv4>::const_iterator parasyte::network::utils::RouteTableIPv4::Find(boost::asio::ip::address_v4 target) const {
-  std::vector<RouteInfoIPv4>::const_iterator default_route_table = DefaultIPv4Route(); // Get the iterator pointing to the default IPv4 route in the route table
-  std::vector<RouteInfoIPv4>::const_iterator it = route_info_list_.begin(); // Initialize the iterator to the beginning of the route_info_list_
+std::vector<parasyte::network::utils::RouteInfoIPv4>::const_iterator parasyte::network::utils::RouteTableIPv4::Find(
+  boost::asio::ip::address_v4 target
+) const {
+  std::vector<RouteInfoIPv4>::const_iterator default_route_table =
+    DefaultIPv4Route();  // Get the iterator pointing to the default IPv4 route in the route table
+  std::vector<RouteInfoIPv4>::const_iterator it =
+    route_info_list_.begin();  // Initialize the iterator to the beginning of the route_info_list_
 
-  for (; it != route_info_list_.end(); ++it) { // Iterate through each route in the route_info_list_
-    if (it == default_route_table) continue; // Skip the default route
-    if (boost::asio::ip::address_v4::broadcast(target, it -> netmask) == it -> dest) break; // Check if the broadcast address of the target matches the destination address of the current route
+  for (; it != route_info_list_.end(); ++it) {  // Iterate through each route in the route_info_list_
+    if (it == default_route_table) continue;    // Skip the default route
+    if (boost::asio::ip::address_v4::broadcast(target, it->netmask) == it->dest)
+      break;  // Check if the broadcast address of the target matches the destination address of the current route
   }
 
-  return (it == route_info_list_.end()) ? default_route_table : it; // Return the iterator pointing to the matching route, or the iterator pointing to the default route if no match is found
+  return (it == route_info_list_.end()) ? default_route_table
+                                        : it;  // Return the iterator pointing to the matching route, or the iterator pointing
+                                               // to the default route if no match is found
 }
 
 /**
  * @brief The std::istream class is a base class for input streams.
- * 
+ *
  * It provides a common interface for reading data from different sources, such as files, strings, or network connections.
  * InitStream is a virtual function that initializes the input stream by reading a line of text from the stream.
  * @param stream The input stream to initialize.
  * @return The initialized input stream.
  * @see https://en.cppreference.com/w/cpp/io/basic_istream
  */
-std::istream &parasyte::network::utils::RouteTableIPv4::InitStream(std::istream &stream) {
+std::istream& parasyte::network::utils::RouteTableIPv4::InitStream(std::istream& stream) {
   std::string line;
   return std::getline(stream, line);
 }
 
 /**
  * Reads the route information from the input stream and populates the RouteInfoIPv4 object.
- * 
+ *
  * @param stream The input stream to read from.
  * @param route_info The RouteInfoIPv4 object to populate.
  * @return The input stream after reading the route information.
  */
-std::ifstream &parasyte::network::utils::RouteTableIPv4::ReadRouteInfo(std::ifstream &stream, RouteInfoIPv4 &route_info) {
+std::ifstream& parasyte::network::utils::RouteTableIPv4::ReadRouteInfo(std::ifstream& stream, RouteInfoIPv4& route_info) {
   uint32_t dest, gateway, netmask;
 
-  stream >> route_info.name >> std::hex >> dest >> gateway >> std::dec >> route_info.flags >> route_info.ref_count >> route_info.use >> route_info.metric >> std::hex >> netmask >> std::dec >> route_info.mtu >> route_info.window >> route_info.ip_route_table;
+  stream >> route_info.name >> std::hex >> dest >> gateway >> std::dec >> route_info.flags >> route_info.ref_count >>
+    route_info.use >> route_info.metric >> std::hex >> netmask >> std::dec >> route_info.mtu >> route_info.window >>
+    route_info.ip_route_table;
   route_info.dest = boost::asio::ip::address_v4(ntohl(dest));
   route_info.gateway = boost::asio::ip::address_v4(ntohl(gateway));
   route_info.netmask = boost::asio::ip::address_v4(ntohl(netmask));
@@ -209,56 +221,62 @@ std::ifstream &parasyte::network::utils::RouteTableIPv4::ReadRouteInfo(std::ifst
 }
 
 /**
-* @brief Constructor for the RouteTableIPv6 class.
-* Reads the route information from the /proc/net/route file and initializes the route_info_list_ member variable.
-*/ 
+ * @brief Constructor for the RouteTableIPv6 class.
+ * Reads the route information from the /proc/net/route file and initializes the route_info_list_ member variable.
+ */
 parasyte::network::utils::RouteTableIPv6::RouteTableIPv6() {
-  std::ifstream route_table_ipv6_proc(proc_route_ipv6_); // Open the /proc/net/route file for reading
-  InitStream(route_table_ipv6_proc); // Initialize the input stream by reading a line of text from the file
+  std::ifstream route_table_ipv6_proc(proc_route_ipv6_);  // Open the /proc/net/route file for reading
+  InitStream(route_table_ipv6_proc);  // Initialize the input stream by reading a line of text from the file
   for (RouteInfoIPv6 route_info; ReadRouteInfo(route_table_ipv6_proc, route_info);) {
-    route_info_list_.push_back(route_info); // Add the read route information to the route_info_list_
-    break; // Exit the loop after reading the first route information
+    route_info_list_.push_back(route_info);  // Add the read route information to the route_info_list_
+    break;                                   // Exit the loop after reading the first route information
   }
 }
 
 /**
  * @brief Returns an iterator pointing to the first occurrence of a default IPv6 route in the route_info_list_ vector.
- * 
- * @return std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator An iterator pointing to the default IPv6 route, or the end iterator if not found.
+ *
+ * @return std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator An iterator pointing to the default IPv6 route,
+ * or the end iterator if not found.
  */
-std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator parasyte::network::utils::RouteTableIPv6::DefaultIPv6Route() const {
-  return std::find_if(route_info_list_.begin(), route_info_list_.end(), [](RouteInfoIPv6 const &route_info) {
+std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator
+parasyte::network::utils::RouteTableIPv6::DefaultIPv6Route() const {
+  return std::find_if(route_info_list_.begin(), route_info_list_.end(), [](RouteInfoIPv6 const& route_info) {
     return route_info.dest == boost::asio::ip::address_v6();
   });
 }
 
 /**
  * @brief Finds the iterator pointing to the first occurrence of a given target address in the route_info_list_ vector.
- * 
- * This function searches for the target address in the route_info_list_ vector and returns the iterator pointing to the first occurrence of the target address.
- * If the target address is not found, it returns the iterator pointing to the default_table_route.
- * 
+ *
+ * This function searches for the target address in the route_info_list_ vector and returns the iterator pointing to the first
+ * occurrence of the target address. If the target address is not found, it returns the iterator pointing to the
+ * default_table_route.
+ *
  * @param target The target address to search for in the route_info_list_ vector.
- * @return std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator The iterator pointing to the first occurrence of the target address, or the iterator pointing to the default_table_route if the target address is not found.
+ * @return std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator The iterator pointing to the first occurrence
+ * of the target address, or the iterator pointing to the default_table_route if the target address is not found.
  */
-std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator parasyte::network::utils::RouteTableIPv6::Find(boost::asio::ip::address_v6 target) const {
+std::vector<parasyte::network::utils::RouteInfoIPv6>::const_iterator parasyte::network::utils::RouteTableIPv6::Find(
+  boost::asio::ip::address_v6 target
+) const {
   std::vector<RouteInfoIPv6>::const_iterator default_table_route = DefaultIPv6Route();
   std::vector<RouteInfoIPv6>::const_iterator it = route_info_list_.begin();
 
   for (; it != route_info_list_.end(); ++it) {
     if (it == default_table_route) continue;
-    if (target == it -> dest) break;
+    if (target == it->dest) break;
   }
   return (it == route_info_list_.end()) ? default_table_route : it;
 }
 
 /**
  * Initializes the input stream by reading a line of text from the stream.
- * 
+ *
  * @param stream The input stream to initialize.
  * @return The initialized input stream.
  */
-auto parasyte::network::utils::RouteTableIPv6::InitStream(std::istream &stream) -> decltype(stream) {
+auto parasyte::network::utils::RouteTableIPv6::InitStream(std::istream& stream) -> decltype(stream) {
   std::string line;
   return std::getline(stream, line);
 }
@@ -270,9 +288,11 @@ auto parasyte::network::utils::RouteTableIPv6::InitStream(std::istream &stream) 
  * @param route_info The RouteInfoIPv6 object to populate with the read route information.
  * @return The input stream after reading the route information
  */
-auto parasyte::network::utils::RouteTableIPv6::ReadRouteInfo(std::ifstream &stream, RouteInfoIPv6 &route_info) -> decltype(stream) {
+auto parasyte::network::utils::RouteTableIPv6::ReadRouteInfo(std::ifstream& stream, RouteInfoIPv6& route_info)
+  -> decltype(stream) {
   std::string dest, source, next_hop;
-  stream >> dest >> route_info.dest_prefix >> source >> std::hex >> route_info.gateway_prefix >> next_hop >> std::hex >> route_info.metric >> std::dec >> route_info.ref_count >> route_info.use >> route_info.flags >> route_info.name;
+  stream >> dest >> route_info.dest_prefix >> source >> std::hex >> route_info.gateway_prefix >> next_hop >> std::hex >>
+    route_info.metric >> std::dec >> route_info.ref_count >> route_info.use >> route_info.flags >> route_info.name;
   route_info.dest = boost::asio::ip::make_address_v6(ReadIPv6Address(dest));
   route_info.gateway = boost::asio::ip::make_address_v6(ReadIPv6Address(source));
   route_info.next_hop = boost::asio::ip::make_address_v6(ReadIPv6Address(next_hop));

--- a/src/network/NetUtils.hpp
+++ b/src/network/NetUtils.hpp
@@ -8,689 +8,679 @@
     without restriction, including without l> imitation the rights to use, copy, modify, merge,
     publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
     to whom the Software is furnished to do so, subject to the following conditions:
-    The above copyright notice and this permission notice shall be included in all copies or 
+    The above copyright notice and this permission notice shall be included in all copies or
     substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
     OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 // Include declarations
 
-#include <string>
-#include <utility>
-#include <cstdint>
-#include <vector>
-#include <fstream>
+#include <netinet/in.h>
+#include <netinet/ip6.h>
+#include <sys/socket.h>
 #include <algorithm>
-#include <boost/asio/detail/config.hpp>
-#include <boost/asio/detail/socket_types.hpp>
+#include <boost/asio.hpp>
 #include <boost/asio/basic_raw_socket.hpp>
+#include <boost/asio/detail/config.hpp>
+#include <boost/asio/detail/push_options.hpp>
+#include <boost/asio/detail/socket_types.hpp>
+#include <boost/asio/ip/address_v4.hpp>
+#include <boost/asio/ip/address_v6.hpp>
 #include <boost/asio/ip/basic_endpoint.hpp>
 #include <boost/asio/ip/basic_resolver.hpp>
 #include <boost/asio/ip/basic_resolver_iterator.hpp>
 #include <boost/asio/ip/basic_resolver_query.hpp>
-#include <boost/asio/detail/push_options.hpp>
-#include <boost/asio/ip/address_v4.hpp>
-#include <boost/asio/ip/address_v6.hpp>
-#include <boost/asio.hpp>
-#include <netinet/ip6.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
 
-#ifdef _WIN32 // For both 32-bit and 64-bit environments
-  #include <Winsock2.h>
-  #include <Ws2tcpip.h>
+#ifdef _WIN32  // For both 32-bit and 64-bit environments
+#include <Winsock2.h>
+#include <Ws2tcpip.h>
 // Ensure to link against the Ws2_32.lib library
 #elif defined(__linux__)
-  #include <linux/ipv6.h>
+#include <linux/ipv6.h>
 #elif defined(__APPLE__)
-  #include <netinet/ip6.h>
+#include <netinet/ip6.h>
 #endif
-
-
 
 /* CODE START */
 
 namespace parasyte {
 namespace network {
-namespace utils {
-  // Utility prototypes
+  namespace utils {
+    // Utility prototypes
 
-  uint16_t Checksum(std::uint16_t *buffer, size_t buffer_size);
-  std::string Inet6AddressToString(const struct in6_addr *addr);
-  std::string Inet4AddressToString(const struct in_addr *addr);
-  boost::asio::ip::address_v4 GetIPv4Address(const std::string &if_name);
-  boost::asio::ip::address_v6 GetIPv6Address(const std::string &if_name);
-  std::string ReadIPv6Address(std::string &str);
+    uint16_t Checksum(std::uint16_t* buffer, size_t buffer_size);
+    std::string Inet6AddressToString(const struct in6_addr* addr);
+    std::string Inet4AddressToString(const struct in_addr* addr);
+    boost::asio::ip::address_v4 GetIPv4Address(const std::string& if_name);
+    boost::asio::ip::address_v6 GetIPv6Address(const std::string& if_name);
+    std::string ReadIPv6Address(std::string& str);
 
-  // Structs
-  struct in6_addr StringToAddress(std::string address);
+    // Structs
+    struct in6_addr StringToAddress(std::string address);
 
-  struct iphdr {
-    unsigned int ihl:4;       // IP header length
-    unsigned int version:4;   // Version
-    uint8_t tos;              // Type of service
-    uint16_t tot_len;         // Total length
-    uint16_t id;              // Identification
-    uint16_t frag_off;        // Fragment offset
-    uint8_t ttl;              // Time to live
-    uint8_t protocol;         // Protocol
-    uint16_t check;           // Checksum
-    uint32_t saddr;           // Source address
-    uint32_t daddr;           // Destination address
-  };
+    struct iphdr {
+        unsigned int ihl : 4;      // IP header length
+        unsigned int version : 4;  // Version
+        uint8_t tos;               // Type of service
+        uint16_t tot_len;          // Total length
+        uint16_t id;               // Identification
+        uint16_t frag_off;         // Fragment offset
+        uint8_t ttl;               // Time to live
+        uint8_t protocol;          // Protocol
+        uint16_t check;            // Checksum
+        uint32_t saddr;            // Source address
+        uint32_t daddr;            // Destination address
+    };
 
+    struct RouteInfoIPv4 {
+        std::string name;
+        boost::asio::ip::address_v4 dest;
+        boost::asio::ip::address_v4 gateway;
+        boost::asio::ip::address_v4 netmask;
+        int ref_count;
+        int use;
+        int metric;
+        uint32_t flags;
+        uint32_t mtu;
+        uint32_t window;
+        unsigned ip_route_table;
+    };
 
-  struct RouteInfoIPv4 {
-    std::string name;
-    boost::asio::ip::address_v4 dest;
-    boost::asio::ip::address_v4 gateway;
-    boost::asio::ip::address_v4 netmask;
-    int ref_count;
-    int use;
-    int metric;
-    uint32_t flags;
-    uint32_t mtu;
-    uint32_t window;
-    unsigned ip_route_table;
-  };
+    struct RouteInfoIPv6 {
+        boost::asio::ip::address_v6 dest;
+        uint16_t dest_prefix;
+        boost::asio::ip::address_v6 gateway;
+        uint16_t gateway_prefix;
+        boost::asio::ip::address_v6 next_hop;
+        uint32_t metric;
+        uint32_t ref_count;
+        uint32_t use;
+        uint32_t flags;
+        std::string name;
+    };
 
-  struct RouteInfoIPv6 {
-    boost::asio::ip::address_v6 dest;
-    uint16_t dest_prefix;
-    boost::asio::ip::address_v6 gateway;
-    uint16_t gateway_prefix;
-    boost::asio::ip::address_v6 next_hop;
-    uint32_t metric;
-    uint32_t ref_count;
-    uint32_t use;
-    uint32_t flags;
-    std::string name;
-  };
+    // Utility classes
 
-  // Utility classes
+    class RawProtocol {
+      public:
+        // Type definitions
+        using endpoint = boost::asio::ip::basic_endpoint<RawProtocol>;
+        using basic_raw_socket = boost::asio::basic_raw_socket<RawProtocol>;
+        using basic_resolver = boost::asio::ip::basic_resolver<RawProtocol>;
 
-  class RawProtocol {
-    public:
-      // Type definitions
-      using endpoint = boost::asio::ip::basic_endpoint<RawProtocol>;
-      using basic_raw_socket = boost::asio::basic_raw_socket<RawProtocol>;
-      using basic_resolver = boost::asio::ip::basic_resolver<RawProtocol>;
+        // Constructors
+        static RawProtocol v4() {
+          return RawProtocol(BOOST_ASIO_OS_DEF(AF_INET), IPPROTO_RAW);
+        }
 
-      // Constructors
-      static RawProtocol v4() {
-        return RawProtocol(BOOST_ASIO_OS_DEF(AF_INET), IPPROTO_RAW);
-      }
+        static RawProtocol v6() {
+          return RawProtocol(BOOST_ASIO_OS_DEF(AF_INET6), IPPROTO_RAW);
+        }
 
-      static RawProtocol v6() {
-        return RawProtocol(BOOST_ASIO_OS_DEF(AF_INET6), IPPROTO_RAW);
-      }
+        // Accessors and mutators
+        int type() const {
+          // Used to determine the protocol type
+          return BOOST_ASIO_OS_DEF(SOCK_RAW);
+        }
 
-      // Accessors and mutators
-      int type() const {
-        // Used to determine the protocol type
-        return BOOST_ASIO_OS_DEF(SOCK_RAW);
-      }
+        int family() const {
+          // Used to determine the protocol family
+          return family_;
+        }
 
-      int family() const {
-        // Used to determine the protocol family
-        return family_;
-      }
+        int protocol() const {
+          // Used to determine the protocol
+          return protocol_;
+        }
 
-      int protocol() const {
-        // Used to determine the protocol
-        return protocol_;
-      }
+        // Mutator for the protocol
+        void protocol(int protocol) {
+          protocol_ = protocol;
+        }
 
-      // Mutator for the protocol
-      void protocol(int protocol) {
-        protocol_ = protocol;
-      }
+        // Comparison operators
+        friend bool operator==(const RawProtocol& p1, const RawProtocol& p2) {
+          // We use friend here to allow access to private members
+          // Used to compare two RawProtocol objects
+          return p1.family_ != p2.family_;
+        }
 
-      // Comparison operators
-      friend bool operator==(const RawProtocol &p1, const RawProtocol &p2) {
-        // We use friend here to allow access to private members
-        // Used to compare two RawProtocol objects
-        return p1.family_ != p2.family_;
-      }
+        friend bool operator!=(const RawProtocol& p1, const RawProtocol& p2) {
+          // We use friend here to allow access to private members
+          // Used to compare two RawProtocol objects
+          return p1.family_ != p2.family_;
+        }
 
-      friend bool operator!=(const RawProtocol &p1, const RawProtocol &p2) {
-        // We use friend here to allow access to private members
-        // Used to compare two RawProtocol objects
-        return p1.family_ != p2.family_;
-      }
+      private:
+        explicit RawProtocol(int family, int protocol) : family_(family), protocol_(protocol) {}
+        int family_;
+        int protocol_;
+    };
 
-    private:
-      explicit RawProtocol(int family, int protocol) : family_(family), protocol_(protocol) {}
-      int family_;
-      int protocol_;
+    class TCPHeader {
+        using header_type = struct tcphdr;
 
-  };
+      public:
+        enum {
+          default_window_value = 4096,
+        };
 
-  class TCPHeader {
-    using header_type = struct tcphdr;
+        // Constructors
+        TCPHeader() : header_{} {}
 
-    public:
-      enum {
-        default_window_value = 4096
-      };
+        // Accessors and mutators
 
-      // Constructors
-      TCPHeader() : header_{} {}
-    
+        uint16_t Source() const {
+          return ntohs(header_.source);
+        }
 
-    // Accessors and mutators
+        uint16_t Destination() const {
+          // Used to get the destination port
+          return ntohs(header_.dest);
+        }
 
-      uint16_t Source() const {
-        return ntohs(header_.source); 
-      }
+        uint32_t Sequence() const {
+          // Used to get the sequence number
+          return ntohl(header_.seq);
+        }
 
-      uint16_t Destination() const {
-        // Used to get the destination port
-        return ntohs(header_.dest);
-      }
+        uint32_t AcknowledgementSequence() const {
+          // Used to get the acknowledgement number
+          return ntohl(header_.ack_seq);
+        }
 
-      uint32_t Sequence() const {
-        // Used to get the sequence number
-        return ntohl(header_.seq);
-      }
+        uint16_t Reserved1() const {
+          // Used to get the reserved field
+          return header_.res1;
+        }
 
-      uint32_t AcknowledgementSequence() const {
-        // Used to get the acknowledgement number
-        return ntohl(header_.ack_seq);
-      }
+        uint16_t DataOffset() const {
+          // Used to get the data offset
+          return header_.doff;
+        }
 
-      uint16_t Reserved1() const {
-        // Used to get the reserved field
-        return header_.res1;
-      }
+        uint16_t Fin() const {
+          // Used to get the FIN flag
+          return header_.fin;
+        }
 
-      uint16_t DataOffset() const {
-        // Used to get the data offset
-        return header_.doff;
-      }
+        uint16_t Syn() const {
+          // Used to get the SYN flag
+          return header_.syn;
+        }
 
-      uint16_t Fin() const {
-        // Used to get the FIN flag
-        return header_.fin;
-      }
+        uint16_t Rst() const {
+          // Used to get the RST flag
+          return header_.rst;
+        }
 
-      uint16_t Syn() const {
-        // Used to get the SYN flag
-        return header_.syn;
-      }
+        uint16_t Psh() const {
+          // Used to get the PSH flag
+          return header_.psh;
+        }
 
-      uint16_t Rst() const {
-        // Used to get the RST flag
-        return header_.rst;
-      }
+        uint16_t Ack() const {
+          // Used to get the ACK flag
+          return header_.ack;
+        }
 
-      uint16_t Psh() const {
-        // Used to get the PSH flag
-        return header_.psh;
-      }
+        uint16_t Urg() const {
+          // Used to get the URG flag
+          return header_.urg;
+        }
 
-      uint16_t Ack() const {
-        // Used to get the ACK flag
-        return header_.ack;
-      }
+        uint16_t Reserved2() const {
+          // Used to get the reserved field
+          return header_.res2;
+        }
 
-      uint16_t Urg() const {
-        // Used to get the URG flag
-        return header_.urg;
-      }
+        uint16_t Window() const {
+          // Used to get the window size
+          return ntohs(header_.window);
+        }
 
-      uint16_t Reserved2() const {
-        // Used to get the reserved field
-        return header_.res2;
-      }
+        uint16_t TCPChecksum() const {
+          // Used to get the checksum
+          return ntohs(header_.check);
+        }
 
-      uint16_t Window() const {
-        // Used to get the window size
-        return ntohs(header_.window);
-      }
+        uint16_t UrgentPointer() const {
+          // Used to get the urgent pointer
+          return ntohs(header_.urg_ptr);
+        }
 
-      uint16_t TCPChecksum() const {
-        // Used to get the checksum
-        return ntohs(header_.check);
-      }
+        void Source(uint16_t source) {
+          // Used to set the source port
+          header_.source = htons(source);
+        }
 
-      uint16_t UrgentPointer() const {
-        // Used to get the urgent pointer
-        return ntohs(header_.urg_ptr);
-      }
+        void Destination(uint16_t destination) {
+          // Used to set the destination port
+          header_.dest = htons(destination);
+        }
 
-      void Source(uint16_t source) {
-        // Used to set the source port
-        header_.source = htons(source);
-      }
+        void Sequence(uint32_t sequence) {
+          // Used to set the sequence number
+          header_.seq = htonl(sequence);
+        }
 
-      void Destination(uint16_t destination) {
-        // Used to set the destination port
-        header_.dest = htons(destination);
-      }
+        void AcknowledgementSequence(uint32_t ack_sequence) {
+          // Used to set the acknowledgement number
+          header_.ack_seq = htonl(ack_sequence);
+        }
 
-      void Sequence(uint32_t sequence) {
-        // Used to set the sequence number
-        header_.seq = htonl(sequence);
-      }
+        void Reserved1(uint16_t reserved) {
+          // Used to set the reserved field
+          header_.res1 = reserved & 0x0F;
+        }
 
-      void AcknowledgementSequence(uint32_t ack_sequence) {
-        // Used to set the acknowledgement number
-        header_.ack_seq = htonl(ack_sequence);
-      }
+        void DataOffset(uint16_t data_offset) {
+          // Used to set the data offset
+          // Bitwise AND operation to ensure that only the last four bits are set
+          header_.doff = data_offset & 0x0F;
+        }
 
-      void Reserved1(uint16_t reserved) {
-        // Used to set the reserved field
-        header_.res1 = reserved & 0x0F;
-      }
+        void Fin(uint16_t fin) {
+          // Used to set the FIN flag
+          header_.fin = (fin != 0) ? 1 : 0;
+        }
 
-      void DataOffset(uint16_t data_offset) {
-        // Used to set the data offset
-        // Bitwise AND operation to ensure that only the last four bits are set
-        header_.doff = data_offset & 0x0F;
-      }
+        void Syn(uint16_t syn) {
+          // Used to set the SYN flag
+          header_.syn = (syn != 0) ? 1 : 0;
+        }
 
-      void Fin(uint16_t fin) {
-        // Used to set the FIN flag
-        header_.fin = (fin != 0) ? 1 : 0;
-      }
+        void Rst(uint16_t rst) {
+          // Used to set the RST flag
+          header_.rst = (rst != 0) ? 1 : 0;
+        }
 
-      void Syn(uint16_t syn) {
-        // Used to set the SYN flag
-        header_.syn = (syn != 0) ? 1 : 0;
-      }
+        void Psh(uint16_t psh) {
+          // Used to set the PSH flag
+          header_.psh = (psh != 0) ? 1 : 0;
+        }
 
-      void Rst(uint16_t rst) {
-        // Used to set the RST flag
-        header_.rst = (rst != 0) ? 1 : 0;
-      }
+        void Ack(uint16_t ack) {
+          // Used to set the ACK flag
+          header_.ack = (ack != 0) ? 1 : 0;
+        }
 
-      void Psh(uint16_t psh) {
-        // Used to set the PSH flag
-        header_.psh = (psh != 0) ? 1 : 0;
-      }
+        void Urg(uint16_t urg) {
+          // Used to set the URG flag
+          header_.urg = (urg != 0) ? 1 : 0;
+        }
 
-      void Ack(uint16_t ack) {
-        // Used to set the ACK flag
-        header_.ack = (ack != 0) ? 1 : 0;
-      }
+        void Reserved2(uint16_t reserved) {
+          // Used to set the reserved field
+          // Bitwise AND operation to ensure that only the last two bits are set
+          header_.res2 = reserved & 0x03;
+        }
 
-      void Urg(uint16_t urg) {
-        // Used to set the URG flag
-        header_.urg = (urg != 0) ? 1 : 0;
-      }
+        void Window(uint16_t window) {
+          // Used to set the window size
+          header_.window = htons(window);
+        }
 
-      void Reserved2(uint16_t reserved) {
-        // Used to set the reserved field
-        // Bitwise AND operation to ensure that only the last two bits are set
-        header_.res2 = reserved & 0x03;
-      }
+        void TCPChecksum(uint16_t checksum) {
+          // Used to set the checksum
+          header_.check = htons(checksum);
+        }
 
-      void Window(uint16_t window) {
-        // Used to set the window size
-        header_.window = htons(window);
-      }
+        void UrgentPointer(uint16_t urgent_pointer) {
+          // Used to set the urgent pointer
+          header_.urg_ptr = htons(urgent_pointer);
+        }
 
-      void TCPChecksum(uint16_t checksum) {
-        // Used to set the checksum
-        header_.check = htons(checksum);
-      }
+        std::size_t length() {
+          return sizeof(header_);
+        }
 
-      void UrgentPointer(uint16_t urgent_pointer) {
-        // Used to set the urgent pointer
-        header_.urg_ptr = htons(urgent_pointer);
-      }
+        char* header() {
+          return reinterpret_cast<char*>(&header_);
+        }
 
-      std::size_t length() {
-        return sizeof(header_);
-      }
+        void CalculateChecksum(uint32_t source_addr, uint32_t destination_addr) {
+          TCPChecksum(0);
+          struct TCPChecksumStruct tcp_checksum = {{}, {}};
+          tcp_checksum.pseudo_header.source = htonl(source_addr);
+          tcp_checksum.pseudo_header.dest = htonl(destination_addr);
+          tcp_checksum.pseudo_header.zero = 0;
+          tcp_checksum.pseudo_header.protocol = IPPROTO_TCP;
+          tcp_checksum.pseudo_header.length = htons(sizeof(header_));
+          tcp_checksum.tcp_header = header_;
+          header_.check = Checksum(reinterpret_cast<uint16_t*>(&tcp_checksum), sizeof(struct TCPChecksumStruct));
+        }
 
-      char *header() {
-        return reinterpret_cast<char*>(&header_);
-      }
-
-      void CalculateChecksum(uint32_t source_addr, uint32_t destination_addr) {
-        TCPChecksum(0);
-        struct TCPChecksumStruct tcp_checksum = {{}, {}};
-        tcp_checksum.pseudo_header.source = htonl(source_addr);
-        tcp_checksum.pseudo_header.dest = htonl(destination_addr);
-        tcp_checksum.pseudo_header.zero = 0;
-        tcp_checksum.pseudo_header.protocol = IPPROTO_TCP;
-        tcp_checksum.pseudo_header.length = htons(sizeof(header_));
-        tcp_checksum.tcp_header = header_;
-        header_.check = Checksum(reinterpret_cast<uint16_t*>(&tcp_checksum), sizeof(struct TCPChecksumStruct));   
-      }
-
-      void CalculateChecksum(const std::string &source_addr, const std::string &destination_addr) {
+        void CalculateChecksum(const std::string& source_addr, const std::string& destination_addr) {
           uint32_t s = static_cast<uint32_t>(GetIPv4Address(source_addr).to_ulong());
           uint32_t d = static_cast<uint32_t>(GetIPv4Address(destination_addr).to_ulong());
           CalculateChecksum(s, d);
-      }
-
-      // Overloaded operators for input and output 
-      friend std::istream &operator>> (std::istream &is, TCPHeader &header) {
-        return is.read(header.header(), static_cast<std::streamsize>(header.length()));
-      }
-
-      friend std::ostream &operator<< (std::ostream &os, TCPHeader &header) {
-        return os.write(header.header(), static_cast<std::streamsize>(header.length()));
-      }
-
-    private:
-      // Structs used for checksum calculation
-      struct TCPHeaderStruct {
-        uint32_t source;
-        uint32_t dest;
-        uint8_t zero;
-        uint8_t protocol;
-        uint16_t length;
-      };
-
-      struct TCPChecksumStruct {
-        struct TCPHeaderStruct pseudo_header;
-        header_type tcp_header;
-      };
-
-      // Member variables
-      header_type header_;
-
-  };
-
-  class RouteTableIPv4 {
-
-    public:
-      RouteTableIPv4();
-      std::vector<RouteInfoIPv4>::const_iterator DefaultIPv4Route() const;
-      std::vector<RouteInfoIPv4>::const_iterator Find(boost::asio::ip::address_v4 target) const;
-
-    private:
-      std::istream &InitStream(std::istream &stream);
-      std::ifstream &ReadRouteInfo(std::ifstream &stream, RouteInfoIPv4 &route_info);
-
-      std::vector<RouteInfoIPv4> route_info_list_;
-      const std::string proc_route_ipv4_ {"/proc/net/route"};
-  };
-
-  class IPv4Header {
-    public:
-      using header_type = struct iphdr;
-      IPv4Header() : header_{} {}
-
-      uint8_t Version() const {
-        return header_.version;
-      }
-
-      uint8_t HeaderLength() const {
-        return header_.ihl;
-      }
-
-      uint8_t TypeOfService() const {
-        return header_.tos;
-      } 
-
-      uint16_t TotalLength() const {
-        return ntohs(header_.tot_len);
-      }
-
-      uint16_t Identification() const {
-        return ntohs(header_.id);
-      }
-
-      uint16_t FragmentOffset() const {
-        return ntohs(header_.frag_off);
-      }
-
-      uint8_t TTL() const {
-        return header_.ttl;
-      }
-
-      uint8_t Protocol() const {
-        return header_.protocol;
-      }
-
-      uint16_t Checksum() const {
-        return ntohs(header_.check);
-      }
-
-      boost::asio::ip::address_v4 SourceAddress() const {
-        return boost::asio::ip::address_v4(ntohl(header_.saddr));
-      }
-
-      boost::asio::ip::address_v4 DestinationAddress() const {
-        return boost::asio::ip::address_v4(ntohl(header_.daddr));
-      }
-
-      void Version(uint8_t version) {
-        // Bitwise AND operation to ensure that only the last four bits are set
-        header_.version = version & 0x0F;
-      }
-
-      void HeaderLength(uint8_t header_length) {
-        // Bitwise AND operation to ensure that only the last four bits are set
-        header_.ihl = header_length & 0x0F;
-      }
-
-      void TypeOfService(uint8_t type_of_service) {
-        header_.tos = type_of_service;
-      }
-
-      void TotalLength(uint16_t total_length) {
-        header_.tot_len = htons(total_length);
-      }
-
-      void Identification(uint16_t identification) {
-        header_.id = htons(identification);
-      }
-
-      void FragmentOffset(uint16_t fragment_offset) {
-        header_.frag_off = htons(fragment_offset);
-      }
-
-      void TTL(uint8_t ttl) {
-        header_.ttl = ttl;
-      }
-
-      void Protocol(uint8_t protocol) {
-        header_.protocol = protocol;
-      }
-
-      void Checksum(uint16_t checksum) {
-        header_.check = htons(checksum);
-      }
-
-      void Checksum() {
-        Checksum(0);
-        Checksum(utils::Checksum(reinterpret_cast<uint16_t*>(&header_), static_cast<uint32_t>(Length())));
-      }
-
-      void SourceAddress(uint32_t source_address) {
-        header_.saddr = htonl(source_address);
-      }
-
-      void DestinationAddress(uint32_t destination_address) {
-        header_.daddr = htonl(destination_address);
-      }
-
-      void SourceAddress(boost::asio::ip::address_v4 source_address) {
-        header_.saddr = htonl(static_cast<uint32_t>(source_address.to_ulong()));
-      }
-
-      void DestinationAddress(boost::asio::ip::address_v4 destination_address) {
-        header_.daddr = htonl(static_cast<uint32_t>(destination_address.to_ulong()));
-      }
-
-      char *Header() {
-        return reinterpret_cast<char*>(&header_);
-      }
-
-      std::size_t Length() {
-        return sizeof(header_);
-      }
-
-      friend std::istream &operator>> (std::istream &stream, IPv4Header &header) {
-        return stream.read(header.Header(), static_cast<std::streamsize>(header.Length()));
-      }
-
-      friend std::ostream &operator<< (std::ostream &stream, IPv4Header &header) {
-        return stream.write(header.Header(), static_cast<std::streamsize>(header.Length()));
-      }
-
-    private:
-      header_type header_;
-  };
-
-
-  class RouteTableIPv6 {
-    public:
-      RouteTableIPv6();
-      std::vector<RouteInfoIPv6>::const_iterator DefaultIPv6Route() const;
-      std::vector<RouteInfoIPv6>::const_iterator Find(boost::asio::ip::address_v6 target) const;
-
-    private:
-      auto InitStream(std::istream &stream) -> decltype(stream);
-      auto ReadRouteInfo(std::ifstream &stream, RouteInfoIPv6 &route_info) -> decltype(stream);
-
-      std::vector<RouteInfoIPv6> route_info_list_;
-      const std::string proc_route_ipv6_ {"/proc/net/ipv6_route"};
-  };
-
-  class IPv6Header {
-    using header_type = struct ipv6hdr;
-
-    public:
-      IPv6Header() : header_{} {}
-
-      uint8_t Version() const {
-        return header_.version;
-      }
-
-      uint8_t TrafficClass() const {
-        return header_.priority;
-      }
-
-      uint16_t PayloadLength() const {
-        return ntohs(header_.payload_len);
-      }
-
-      uint8_t NextHeader() const {
-        return header_.nexthdr;
-      }
-
-      uint8_t HopLimit() const {
-        return header_.hop_limit;
-      }
-
-      boost::asio::ip::address_v6 SourceAddress() const {
-        return boost::asio::ip::make_address_v6(utils::Inet6AddressToString(&header_.saddr));
-      }
-
-      boost::asio::ip::address_v6 DestinationAddress() const {
-        return boost::asio::ip::make_address_v6(utils::Inet6AddressToString(&header_.daddr));
-      }
-
-      void Version(uint8_t version) {
-        // bitwise AND operation to ensure that only the last four bits are set
-        header_.version = version & 0x0F;
-      }
-
-      void TrafficClass(uint8_t traffic_class) {
-        // bitwise AND operation to ensure that only the last four bits are set
-        header_.priority = traffic_class & 0x0F;
-      }
-
-      void PayloadLength(uint16_t payload_length) {
-        header_.payload_len = htons(payload_length);
-      }
-
-      void NextHeader(uint8_t next_header) {
-        header_.nexthdr = next_header;
-      }
-
-      void HopLimit(uint8_t hop_limit) {
-        header_.hop_limit = hop_limit;
-      }
-
-      void SourceAddress(boost::asio::ip::address_v6 source_address) {
-        header_.saddr = utils::StringToAddress(source_address.to_string());
-      }
-
-      void DestinationAddress(boost::asio::ip::address_v6 destination_address) {
-        header_.daddr = utils::StringToAddress(destination_address.to_string());
-      }
-
-
-      char *Header() {
-        return reinterpret_cast<char*>(&header_);
-      }
-
-      std::size_t Length() {
-        return sizeof(header_);
-      }
-
-      friend std::istream &operator>> (std::istream &stream, IPv6Header &header) {
-        return stream.read(header.Header(), static_cast<std::streamsize>(header.Length()));
-      }
-
-      friend std::ostream &operator<< (std::ostream &stream, IPv6Header &header) {
-        return stream.write(header.Header(), static_cast<std::streamsize>(header.Length()));
-      }
-      
-    private:
-      header_type header_;
-  };
-
-  template<int Level, int Name, int Init = true >
-  class BinaryOption {
-    public:
-      BinaryOption() = default;
-      BinaryOption(bool option_value) : option_value_(option_value) {}
-      ~BinaryOption() = default;
-
-      template<typename Protocol>
-      int level(Protocol const&) const {
-        return Level;
-      }
-
-      template<typename Protocol>
-      int name(Protocol const&) const {
-        return Name;
-      }
-
-      template<typename Protocol>
-      void *data(Protocol const&) {
-        return reinterpret_cast<void*>(&option_value_);
-      }
-
-      template<typename Protocol>
-      void const *data(Protocol const&) const {
-        return reinterpret_cast<void const*>(&option_value_);
-      }
-
-      template<typename Protocol>
-      int size(Protocol const&) const {
-        return sizeof(option_value_);
-      }
-
-      void SetOptionValue(bool option_value) {
-        option_value_ = option_value;
-      }
-
-      bool GetOptionValue() const {
-        return option_value_;
-      }
-
-    private:
-      bool option_value_ = Init;
-
-  };
-  
-}
+        }
+
+        // Overloaded operators for input and output
+        friend std::istream& operator>>(std::istream& is, TCPHeader& header) {
+          return is.read(header.header(), static_cast<std::streamsize>(header.length()));
+        }
+
+        friend std::ostream& operator<<(std::ostream& os, TCPHeader& header) {
+          return os.write(header.header(), static_cast<std::streamsize>(header.length()));
+        }
+
+      private:
+        // Structs used for checksum calculation
+        struct TCPHeaderStruct {
+            uint32_t source;
+            uint32_t dest;
+            uint8_t zero;
+            uint8_t protocol;
+            uint16_t length;
+        };
+
+        struct TCPChecksumStruct {
+            struct TCPHeaderStruct pseudo_header;
+            header_type tcp_header;
+        };
+
+        // Member variables
+        header_type header_;
+    };
+
+    class RouteTableIPv4 {
+      public:
+        RouteTableIPv4();
+        std::vector<RouteInfoIPv4>::const_iterator DefaultIPv4Route() const;
+        std::vector<RouteInfoIPv4>::const_iterator Find(boost::asio::ip::address_v4 target) const;
+
+      private:
+        std::istream& InitStream(std::istream& stream);
+        std::ifstream& ReadRouteInfo(std::ifstream& stream, RouteInfoIPv4& route_info);
+
+        std::vector<RouteInfoIPv4> route_info_list_;
+        const std::string proc_route_ipv4_{"/proc/net/route"};
+    };
+
+    class IPv4Header {
+      public:
+        using header_type = struct iphdr;
+        IPv4Header() : header_{} {}
+
+        uint8_t Version() const {
+          return header_.version;
+        }
+
+        uint8_t HeaderLength() const {
+          return header_.ihl;
+        }
+
+        uint8_t TypeOfService() const {
+          return header_.tos;
+        }
+
+        uint16_t TotalLength() const {
+          return ntohs(header_.tot_len);
+        }
+
+        uint16_t Identification() const {
+          return ntohs(header_.id);
+        }
+
+        uint16_t FragmentOffset() const {
+          return ntohs(header_.frag_off);
+        }
+
+        uint8_t TTL() const {
+          return header_.ttl;
+        }
+
+        uint8_t Protocol() const {
+          return header_.protocol;
+        }
+
+        uint16_t Checksum() const {
+          return ntohs(header_.check);
+        }
+
+        boost::asio::ip::address_v4 SourceAddress() const {
+          return boost::asio::ip::address_v4(ntohl(header_.saddr));
+        }
+
+        boost::asio::ip::address_v4 DestinationAddress() const {
+          return boost::asio::ip::address_v4(ntohl(header_.daddr));
+        }
+
+        void Version(uint8_t version) {
+          // Bitwise AND operation to ensure that only the last four bits are set
+          header_.version = version & 0x0F;
+        }
+
+        void HeaderLength(uint8_t header_length) {
+          // Bitwise AND operation to ensure that only the last four bits are set
+          header_.ihl = header_length & 0x0F;
+        }
+
+        void TypeOfService(uint8_t type_of_service) {
+          header_.tos = type_of_service;
+        }
+
+        void TotalLength(uint16_t total_length) {
+          header_.tot_len = htons(total_length);
+        }
+
+        void Identification(uint16_t identification) {
+          header_.id = htons(identification);
+        }
+
+        void FragmentOffset(uint16_t fragment_offset) {
+          header_.frag_off = htons(fragment_offset);
+        }
+
+        void TTL(uint8_t ttl) {
+          header_.ttl = ttl;
+        }
+
+        void Protocol(uint8_t protocol) {
+          header_.protocol = protocol;
+        }
+
+        void Checksum(uint16_t checksum) {
+          header_.check = htons(checksum);
+        }
+
+        void Checksum() {
+          Checksum(0);
+          Checksum(utils::Checksum(reinterpret_cast<uint16_t*>(&header_), static_cast<uint32_t>(Length())));
+        }
+
+        void SourceAddress(uint32_t source_address) {
+          header_.saddr = htonl(source_address);
+        }
+
+        void DestinationAddress(uint32_t destination_address) {
+          header_.daddr = htonl(destination_address);
+        }
+
+        void SourceAddress(boost::asio::ip::address_v4 source_address) {
+          header_.saddr = htonl(static_cast<uint32_t>(source_address.to_ulong()));
+        }
+
+        void DestinationAddress(boost::asio::ip::address_v4 destination_address) {
+          header_.daddr = htonl(static_cast<uint32_t>(destination_address.to_ulong()));
+        }
+
+        char* Header() {
+          return reinterpret_cast<char*>(&header_);
+        }
+
+        std::size_t Length() {
+          return sizeof(header_);
+        }
+
+        friend std::istream& operator>>(std::istream& stream, IPv4Header& header) {
+          return stream.read(header.Header(), static_cast<std::streamsize>(header.Length()));
+        }
+
+        friend std::ostream& operator<<(std::ostream& stream, IPv4Header& header) {
+          return stream.write(header.Header(), static_cast<std::streamsize>(header.Length()));
+        }
+
+      private:
+        header_type header_;
+    };
+
+    class RouteTableIPv6 {
+      public:
+        RouteTableIPv6();
+        std::vector<RouteInfoIPv6>::const_iterator DefaultIPv6Route() const;
+        std::vector<RouteInfoIPv6>::const_iterator Find(boost::asio::ip::address_v6 target) const;
+
+      private:
+        auto InitStream(std::istream& stream) -> decltype(stream);
+        auto ReadRouteInfo(std::ifstream& stream, RouteInfoIPv6& route_info) -> decltype(stream);
+
+        std::vector<RouteInfoIPv6> route_info_list_;
+        const std::string proc_route_ipv6_{"/proc/net/ipv6_route"};
+    };
+
+    class IPv6Header {
+        using header_type = struct ipv6hdr;
+
+      public:
+        IPv6Header() : header_{} {}
+
+        uint8_t Version() const {
+          return header_.version;
+        }
+
+        uint8_t TrafficClass() const {
+          return header_.priority;
+        }
+
+        uint16_t PayloadLength() const {
+          return ntohs(header_.payload_len);
+        }
+
+        uint8_t NextHeader() const {
+          return header_.nexthdr;
+        }
+
+        uint8_t HopLimit() const {
+          return header_.hop_limit;
+        }
+
+        boost::asio::ip::address_v6 SourceAddress() const {
+          return boost::asio::ip::make_address_v6(utils::Inet6AddressToString(&header_.saddr));
+        }
+
+        boost::asio::ip::address_v6 DestinationAddress() const {
+          return boost::asio::ip::make_address_v6(utils::Inet6AddressToString(&header_.daddr));
+        }
+
+        void Version(uint8_t version) {
+          // bitwise AND operation to ensure that only the last four bits are set
+          header_.version = version & 0x0F;
+        }
+
+        void TrafficClass(uint8_t traffic_class) {
+          // bitwise AND operation to ensure that only the last four bits are set
+          header_.priority = traffic_class & 0x0F;
+        }
+
+        void PayloadLength(uint16_t payload_length) {
+          header_.payload_len = htons(payload_length);
+        }
+
+        void NextHeader(uint8_t next_header) {
+          header_.nexthdr = next_header;
+        }
+
+        void HopLimit(uint8_t hop_limit) {
+          header_.hop_limit = hop_limit;
+        }
+
+        void SourceAddress(boost::asio::ip::address_v6 source_address) {
+          header_.saddr = utils::StringToAddress(source_address.to_string());
+        }
+
+        void DestinationAddress(boost::asio::ip::address_v6 destination_address) {
+          header_.daddr = utils::StringToAddress(destination_address.to_string());
+        }
+
+        char* Header() {
+          return reinterpret_cast<char*>(&header_);
+        }
+
+        std::size_t Length() {
+          return sizeof(header_);
+        }
+
+        friend std::istream& operator>>(std::istream& stream, IPv6Header& header) {
+          return stream.read(header.Header(), static_cast<std::streamsize>(header.Length()));
+        }
+
+        friend std::ostream& operator<<(std::ostream& stream, IPv6Header& header) {
+          return stream.write(header.Header(), static_cast<std::streamsize>(header.Length()));
+        }
+
+      private:
+        header_type header_;
+    };
+
+    template<int Level, int Name, int Init = true>
+    class BinaryOption {
+      public:
+        BinaryOption() = default;
+        BinaryOption(bool option_value) : option_value_(option_value) {}
+        ~BinaryOption() = default;
+
+        template<typename Protocol>
+        int level(Protocol const&) const {
+          return Level;
+        }
+
+        template<typename Protocol>
+        int name(Protocol const&) const {
+          return Name;
+        }
+
+        template<typename Protocol>
+        void* data(Protocol const&) {
+          return reinterpret_cast<void*>(&option_value_);
+        }
+
+        template<typename Protocol>
+        void const* data(Protocol const&) const {
+          return reinterpret_cast<void const*>(&option_value_);
+        }
+
+        template<typename Protocol>
+        int size(Protocol const&) const {
+          return sizeof(option_value_);
+        }
+
+        void SetOptionValue(bool option_value) {
+          option_value_ = option_value;
+        }
+
+        bool GetOptionValue() const {
+          return option_value_;
+        }
+
+      private:
+        bool option_value_ = Init;
+    };
+
+  }
 }
 }
 
-#endif // PARASYTE_NETWORK_NETUTILS_HPP_
+#endif  // PARASYTE_NETWORK_NETUTILS_HPP_


### PR DESCRIPTION
Approximating ~90% of the style that exists.

Notable differences:

 - inner namespaces all get indents
 - default-access class members get "double indent" for consistency with access-modified members
 - there was much contradictory pointer/reference alignment. Inferring it per file did not lead to fewer changes
 - only stream operator overloads received space before parameter list; I changed that to avoid introducing spaces with operator== etc.
 - some short if/else statements existed on a single line. Telling clang-format to AllowShortIfStatementsOnASingleLine tried to put a few more on a single line, which I avoided by insert an empty `//` comment

The code has some manual touch-ups that made clang-format give better results (e.g. moving comments to a separate line)

The code is now inert under re-format

```bash
find -iname '*.[hc]pp' -exec clang-format -i {} \;
```